### PR TITLE
baseDir pointing to a sub-folder of the WC support

### DIFF
--- a/sonar-scm-svn-plugin/src/main/java/org/sonar/plugins/scm/svn/SvnScmProvider.java
+++ b/sonar-scm-svn-plugin/src/main/java/org/sonar/plugins/scm/svn/SvnScmProvider.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.plugins.scm.svn;
 
+
 import org.sonar.api.batch.scm.BlameCommand;
 import org.sonar.api.batch.scm.ScmProvider;
 
@@ -39,7 +40,14 @@ public class SvnScmProvider extends ScmProvider {
 
   @Override
   public boolean supports(File baseDir) {
-    return new File(baseDir, ".svn").exists();
+    File folder = baseDir;
+    while (folder != null) {
+      if (new File(folder, ".svn").exists()) {
+        return true;
+      }
+      folder = folder.getParentFile();
+    }
+    return false;
   }
 
   @Override

--- a/sonar-scm-svn-plugin/src/test/java/org/sonar/plugins/scm/svn/SvnBlameCommandTest.java
+++ b/sonar-scm-svn-plugin/src/test/java/org/sonar/plugins/scm/svn/SvnBlameCommandTest.java
@@ -70,6 +70,10 @@ import static org.mockito.Mockito.when;
 @RunWith(Parameterized.class)
 public class SvnBlameCommandTest {
 
+  /*
+   * Note about SONARSCSVN-11: The case of a project baseDir is in a subFolder of working copy is part of method tests by default
+   */
+
   private static final String DUMMY_JAVA = "src/main/java/org/dummy/Dummy.java";
 
   @Rule

--- a/sonar-scm-svn-plugin/src/test/java/org/sonar/plugins/scm/svn/SvnScmProviderTest.java
+++ b/sonar-scm-svn-plugin/src/test/java/org/sonar/plugins/scm/svn/SvnScmProviderTest.java
@@ -53,6 +53,12 @@ public class SvnScmProviderTest {
     File svnBaseDir = temp.newFolder();
     new File(svnBaseDir, ".svn").mkdir();
     assertThat(new SvnScmProvider(null).supports(svnBaseDir)).isTrue();
+
+    File svnBaseDirSubFolder = temp.newFolder();
+    new File(svnBaseDirSubFolder, ".svn").mkdir();
+    File projectBaseDir = new File(svnBaseDirSubFolder, "folder");
+    projectBaseDir.mkdir();
+    assertThat(new SvnScmProvider(null).supports(projectBaseDir)).isTrue();
   }
 
 }


### PR DESCRIPTION
PR for [SONARSCSVN-11](https://jira.sonarsource.com/browse/SONARSCSVN-11).

In fact, the *core* plugin (SvnKit usage) already supports this use case.
The change is mainly on auto-detection & UTs/ITs.

In addition of UTs/ITs, 1.4-SNAPSHOT tested with SQ LTS on real project use case.