### PR TITLE
Upgrade SVNKit dependency to latest release (1.9.0 --> 1.9.2)

### DIFF
--- a/sonar-scm-svn-plugin/pom.xml
+++ b/sonar-scm-svn-plugin/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>org.tmatesoft.svnkit</groupId>
       <artifactId>svnkit</artifactId>
-      <version>1.9.0</version>
+      <version>1.9.2</version>
     </dependency>
 
     <!-- unit tests -->


### PR DESCRIPTION
Hi,

After a problem with the SonarSVN plugin and a discussion about it in the SonarQube Google Group ([Sonar SVN Blame fails due to "svn: E200007: Retrieval of mergeinfo unsupported"](https://groups.google.com/forum/#!topic/sonarqube/1xDuZCFLn1I)), I found that there's a bug in SVNKit itself (see: [SVNKIT-712](https://issues.tmatesoft.com/issue/SVNKIT-712)).

This bug has recently been resolved in the new SVNKit release 1.9.2
It would be great if the SonarSVN plugin could incorporate this in the next version!

Cheers,
Dominik