### PR TITLE
Fix root svn url problem

### DIFF
--- a/sonar-scm-svn-plugin/src/main/java/org/sonar/plugins/scm/svn/SvnScmProvider.java
+++ b/sonar-scm-svn-plugin/src/main/java/org/sonar/plugins/scm/svn/SvnScmProvider.java
@@ -109,6 +109,13 @@ public class SvnScmProvider extends ScmProvider {
 
     // SVN path of the repo root, for example: /C:/Users/JANOSG~1/AppData/Local/Temp/x/y
     Path svnRootPath = toPath(svnInfo.getRepositoryRootURL());
+
+    /* the svn root path is "" (which is returned by svnkit e.g. for urls like http://svnserver/) set it to "/". to
+    avoid crashing when using Path.relativize later */
+    if(svnRootPath.equals(Paths.get(""))){
+      svnRootPath = Paths.get("/");
+    }
+
     // SVN path of projectBasedir, for example: /C:/Users/JANOSG~1/AppData/Local/Temp/x/y/branches/b1
     Path svnProjectPath = toPath(svnInfo.getURL());
     // path of projectBasedir, as "absolute path within the SVN repo", for example: /branches/b1

--- a/sonar-scm-svn-plugin/src/main/java/org/sonar/plugins/scm/svn/SvnScmProvider.java
+++ b/sonar-scm-svn-plugin/src/main/java/org/sonar/plugins/scm/svn/SvnScmProvider.java
@@ -103,7 +103,7 @@ public class SvnScmProvider extends ScmProvider {
     return null;
   }
 
-  private static Set<Path> computeChangedPaths(Path projectBasedir, SVNClientManager clientManager) throws SVNException {
+  static Set<Path> computeChangedPaths(Path projectBasedir, SVNClientManager clientManager) throws SVNException {
     SVNWCClient wcClient = clientManager.getWCClient();
     SVNInfo svnInfo = wcClient.doInfo(projectBasedir.toFile(), null);
 


### PR DESCRIPTION
When a svn repository is located on the root level of the url (e.g. http://svnserver/), a crash happens when running the svn plugin with a custom branch name.

The first commit is a test demonstrating the issue, the second commit is the fix for the issue.

See internal SUPPORT-14039 ticket for all details.