### PR TITLE
SONARSCSVN-29 Update QA to next LTS (7.9)

### DIFF
--- a/.cix.yml
+++ b/.cix.yml
@@ -4,7 +4,7 @@
 
 SQ_VERSION: 
   - DEV
-  - LATEST_RELEASE[6.7]
+  - LATEST_RELEASE[7.9]
 
 SLAVE:
   - linux

--- a/its/src/test/java/com/sonarsource/it/scm/SvnTest.java
+++ b/its/src/test/java/com/sonarsource/it/scm/SvnTest.java
@@ -79,7 +79,7 @@ public class SvnTest {
 
   @ClassRule
   public static Orchestrator orchestrator = Orchestrator.builderEnv()
-    .setSonarVersion(System.getProperty("sonar.runtimeVersion", "LATEST_RELEASE[6.7]"))
+    .setSonarVersion(System.getProperty("sonar.runtimeVersion", "LATEST_RELEASE[7.9]"))
     .addPlugin(FileLocation.byWildcardMavenFilename(new File("../sonar-scm-svn-plugin/target"), "sonar-scm-svn-plugin-*.jar"))
     .addPlugin(MavenLocation.of("org.sonarsource.java", "sonar-java-plugin", "LATEST_RELEASE"))
     .build();


### PR DESCRIPTION
The release of SonarJava 6 breaks our QA, as SonarJava is not compatible with 6.7 LTS. Upgrade QA to run against 7.9.