### PR TITLE
Update parent POM to fix coverage reporting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.parent</groupId>
     <artifactId>parent</artifactId>
-    <version>49</version>
+    <version>51</version>
   </parent>
   <groupId>org.sonarsource.scm.svn</groupId>
   <artifactId>svn</artifactId>

--- a/travis.sh
+++ b/travis.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 function configureTravis {
   mkdir -p ~/.local
-  curl -sSL https://github.com/SonarSource/travis-utils/tarball/v55 | tar zx --strip-components 1 -C ~/.local
+  curl -sSL https://github.com/SonarSource/travis-utils/tarball/v57 | tar zx --strip-components 1 -C ~/.local
   source ~/.local/bin/install                                                                                                                                    
 }
 configureTravis


### PR DESCRIPTION
Use v51, which includes the new `coverage` profile.